### PR TITLE
docs: improve installation guides for NAS and Docker-HA users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ This project is developed and maintained in my free time. If it saves you time o
 
 ## Quick Start
 
+### Which installation method is right for you?
+
+| Your setup | Recommended method |
+|---|---|
+| Home Assistant OS (HAOS) or Supervised | [Home Assistant Add-on](#home-assistant) |
+| Home Assistant Container (Docker) | [Docker](#docker--podman) |
+| NAS (Synology, QNAP, Unraid) | [Docker](#docker--podman) |
+| No Docker, no Home Assistant | [Standalone App](#standalone-apps-windows-macos-linux) |
+
+> **Note:** The Home Assistant Add-on requires **Home Assistant OS** or **Supervised** installation. If you run HA as a Docker container (e.g. on a NAS), use the Docker method instead — it works alongside your existing HA container. This is **not** a HACS integration — it's a standalone tool that generates tokens for use with the [Kia/Hyundai Connect integration](https://github.com/Hyundai-Kia-Connect/kia_uvo).
+
 ### Home Assistant
 
 → **[Home Assistant Setup Guide](docs/HOME_ASSISTANT.md)**
@@ -63,6 +74,8 @@ This project is developed and maintained in my free time. If it saves you time o
 ### Docker / Podman
 
 → **[Docker Setup Guide](docs/DOCKER.md)**
+
+Works on any system with Docker: Linux servers, Synology/QNAP NAS, Unraid, or alongside an existing HA Container installation.
 
 ```bash
 docker run -d --name bluelink-token -p 9876:9876 \
@@ -220,6 +233,28 @@ Use the refresh token as the **password** (not your Bluelink password) when conf
 
 - [evcc](https://docs.evcc.io/en/docs/devices/vehicles#hyundai-bluelink) — Hyundai/Kia vehicle integration
 - [Home Assistant Kia/Hyundai integration](https://github.com/Hyundai-Kia-Connect/kia_uvo)
+
+## FAQ
+
+### I can't find this in HACS
+
+This is not a HACS integration. It's a Home Assistant **Add-on** that requires HAOS or Supervised. If you run HA as a Docker container (e.g. on a NAS), use the [Docker setup](docs/DOCKER.md) instead.
+
+### I don't have an Add-on store in Home Assistant
+
+Your HA installation is likely the "Container" type (common on NAS systems). The Add-on store is only available on HAOS and Supervised installations. Use the [Docker method](docs/DOCKER.md) — it runs as a separate container alongside your HA.
+
+### Does this work on Synology / QNAP / Unraid?
+
+Yes. Use the [Docker setup](docs/DOCKER.md) — there are NAS-specific instructions for Synology, QNAP, and Unraid.
+
+### What's the difference between this and the old browser-based scripts?
+
+The old scripts (e.g. from RustyDust/bluelink_refresh_token) used Selenium/Playwright to automate a real browser. They broke when Kia/Hyundai added bot detection. This tool works **headless** by reverse-engineering the official app's API calls — no browser, no CAPTCHA, no bot detection issues.
+
+### I get "classified as an abusing request and blocked"
+
+This error affects the old browser-based token scripts. This tool uses a different approach (direct API calls with the app's TLS fingerprint) and is not affected by this block.
 
 ## Support
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,5 +1,37 @@
 # Docker / Podman Setup
 
+This is the recommended method if you:
+- Run Home Assistant as a Docker container (no Add-on store available)
+- Use a NAS (Synology, QNAP, Unraid, TrueNAS)
+- Have any Linux server with Docker installed
+
+The container runs independently — it does not need to be installed "inside" Home Assistant.
+
+## NAS Quick Start (Synology, QNAP, Unraid)
+
+### Synology (Container Manager / Docker)
+
+1. Open **Container Manager** (or Docker package on older DSM)
+2. Go to **Registry** → search for `ghcr.io/tma84/bluelink-token`
+3. Download the `latest` tag
+4. Create a container with:
+   - **Port:** Local port `9876` → Container port `9876`
+   - **Environment variables:** see [Environment Variables](#environment-variables) below
+   - **Command:** `/run-standalone.sh`
+5. Start the container and open `http://your-nas-ip:9876`
+
+### QNAP (Container Station)
+
+1. Open **Container Station**
+2. Click **Create** → **Create Application** (or use Docker CLI via SSH)
+3. Use the Docker Compose example below
+4. Access the Web UI at `http://your-nas-ip:9876`
+
+### Unraid
+
+1. Open a terminal and run the `docker run` command below
+2. Or add via **Docker** tab → **Add Container** with the image `ghcr.io/tma84/bluelink-token:latest`
+
 ## Docker Compose (recommended)
 
 ```yaml

--- a/docs/HOME_ASSISTANT.md
+++ b/docs/HOME_ASSISTANT.md
@@ -1,5 +1,18 @@
 # Home Assistant Setup
 
+## Requirements
+
+This add-on requires **Home Assistant OS (HAOS)** or a **Supervised** installation. These are the only installation types that support the Add-on store.
+
+| HA Installation Type | Add-on supported? | Alternative |
+|---|---|---|
+| Home Assistant OS (HAOS) | ✅ Yes | — |
+| Supervised | ✅ Yes | — |
+| Container (Docker) | ❌ No | Use [Docker setup](DOCKER.md) alongside your HA container |
+| Core (venv) | ❌ No | Use [Docker setup](DOCKER.md) or [Standalone app](../README.md#standalone-apps-windows-macos-linux) |
+
+> **Not a HACS integration:** This is a Home Assistant **Add-on** (installed via the Add-on store), not a HACS custom component. You will not find it in HACS. The generated token is used with the separate [Kia/Hyundai Connect integration](https://github.com/Hyundai-Kia-Connect/kia_uvo).
+
 ## Installation
 
 1. Add this repository to your Home Assistant app store:


### PR DESCRIPTION
Addresses common questions from community issues (kia_uvo#1632, hyundai_kia_connect_api#1113, bluelink_refresh_token#7).

## Changes

- **README.md**: Added installation method overview table and FAQ section
- **docs/HOME_ASSISTANT.md**: Added requirements section clarifying HAOS/Supervised requirement
- **docs/DOCKER.md**: Added NAS quick start guides (Synology, QNAP, Unraid)

## Context

Users in other repos frequently ask:
- Why they can't find this in HACS
- How to install when they don't have an Add-on store (Docker-HA on NAS)
- What the difference is to the old browser-based scripts

These docs changes make the answers immediately visible.