### PR TITLE
fix: prevent HA sensor expiry date from drifting daily

### DIFF
--- a/bluelink-token-dev/web.py
+++ b/bluelink-token-dev/web.py
@@ -282,9 +282,33 @@ def update_ha_sensor(brand, username="", days_remaining=None):
     try:
         now = datetime.now(timezone.utc)
         if days_remaining is not None:
-            expiry = now + timedelta(days=days_remaining)
-            remaining = days_remaining
+            # When refreshing an existing sensor, read the stored expiry date
+            # instead of recalculating from days_remaining (avoids daily drift)
+            vkey = _vehicle_key(brand, username)
+            sensor_id = f"sensor.bluelink_token_expiry_{vkey}"
+            existing_expiry = None
+            try:
+                resp = req_lib.get(
+                    f"http://supervisor/core/api/states/{sensor_id}",
+                    headers={"Authorization": f"Bearer {supervisor_token}"}, timeout=3)
+                if resp.status_code == 200:
+                    existing_state = resp.json().get("state", "")
+                    if existing_state and existing_state not in ("unknown", "unavailable"):
+                        existing_expiry = existing_state
+            except Exception:
+                pass
+            if existing_expiry:
+                # Re-publish the existing expiry date as-is (no drift)
+                from datetime import date
+                expiry_date = date.fromisoformat(existing_expiry)
+                remaining = (expiry_date - date.today()).days
+                expiry = datetime(expiry_date.year, expiry_date.month, expiry_date.day, tzinfo=timezone.utc)
+            else:
+                # No existing sensor — calculate from days_remaining
+                expiry = now + timedelta(days=days_remaining)
+                remaining = days_remaining
         else:
+            # Fresh token generation — calculate new expiry
             expiry = now + timedelta(days=TOKEN_EXPIRY_DAYS)
             remaining = TOKEN_EXPIRY_DAYS
         headers = {
@@ -301,7 +325,7 @@ def update_ha_sensor(brand, username="", days_remaining=None):
                 "friendly_name": f"Bluelink Token ({brand_name} {masked_user})",
                 "device_class": "date",
                 "icon": "mdi:key-clock",
-                "generated": (now - timedelta(days=TOKEN_EXPIRY_DAYS - remaining)).strftime("%Y-%m-%d %H:%M"),
+                "generated": (expiry - timedelta(days=TOKEN_EXPIRY_DAYS)).strftime("%Y-%m-%d %H:%M"),
                 "expires": expiry.strftime("%Y-%m-%d %H:%M"),
                 "days_remaining": remaining,
                 "brand": brand,

--- a/bluelink-token/web.py
+++ b/bluelink-token/web.py
@@ -282,9 +282,33 @@ def update_ha_sensor(brand, username="", days_remaining=None):
     try:
         now = datetime.now(timezone.utc)
         if days_remaining is not None:
-            expiry = now + timedelta(days=days_remaining)
-            remaining = days_remaining
+            # When refreshing an existing sensor, read the stored expiry date
+            # instead of recalculating from days_remaining (avoids daily drift)
+            vkey = _vehicle_key(brand, username)
+            sensor_id = f"sensor.bluelink_token_expiry_{vkey}"
+            existing_expiry = None
+            try:
+                resp = req_lib.get(
+                    f"http://supervisor/core/api/states/{sensor_id}",
+                    headers={"Authorization": f"Bearer {supervisor_token}"}, timeout=3)
+                if resp.status_code == 200:
+                    existing_state = resp.json().get("state", "")
+                    if existing_state and existing_state not in ("unknown", "unavailable"):
+                        existing_expiry = existing_state
+            except Exception:
+                pass
+            if existing_expiry:
+                # Re-publish the existing expiry date as-is (no drift)
+                from datetime import date
+                expiry_date = date.fromisoformat(existing_expiry)
+                remaining = (expiry_date - date.today()).days
+                expiry = datetime(expiry_date.year, expiry_date.month, expiry_date.day, tzinfo=timezone.utc)
+            else:
+                # No existing sensor — calculate from days_remaining
+                expiry = now + timedelta(days=days_remaining)
+                remaining = days_remaining
         else:
+            # Fresh token generation — calculate new expiry
             expiry = now + timedelta(days=TOKEN_EXPIRY_DAYS)
             remaining = TOKEN_EXPIRY_DAYS
         headers = {
@@ -301,7 +325,7 @@ def update_ha_sensor(brand, username="", days_remaining=None):
                 "friendly_name": f"Bluelink Token ({brand_name} {masked_user})",
                 "device_class": "date",
                 "icon": "mdi:key-clock",
-                "generated": (now - timedelta(days=TOKEN_EXPIRY_DAYS - remaining)).strftime("%Y-%m-%d %H:%M"),
+                "generated": (expiry - timedelta(days=TOKEN_EXPIRY_DAYS)).strftime("%Y-%m-%d %H:%M"),
                 "expires": expiry.strftime("%Y-%m-%d %H:%M"),
                 "days_remaining": remaining,
                 "brand": brand,

--- a/standalone/web.py
+++ b/standalone/web.py
@@ -282,9 +282,33 @@ def update_ha_sensor(brand, username="", days_remaining=None):
     try:
         now = datetime.now(timezone.utc)
         if days_remaining is not None:
-            expiry = now + timedelta(days=days_remaining)
-            remaining = days_remaining
+            # When refreshing an existing sensor, read the stored expiry date
+            # instead of recalculating from days_remaining (avoids daily drift)
+            vkey = _vehicle_key(brand, username)
+            sensor_id = f"sensor.bluelink_token_expiry_{vkey}"
+            existing_expiry = None
+            try:
+                resp = req_lib.get(
+                    f"http://supervisor/core/api/states/{sensor_id}",
+                    headers={"Authorization": f"Bearer {supervisor_token}"}, timeout=3)
+                if resp.status_code == 200:
+                    existing_state = resp.json().get("state", "")
+                    if existing_state and existing_state not in ("unknown", "unavailable"):
+                        existing_expiry = existing_state
+            except Exception:
+                pass
+            if existing_expiry:
+                # Re-publish the existing expiry date as-is (no drift)
+                from datetime import date
+                expiry_date = date.fromisoformat(existing_expiry)
+                remaining = (expiry_date - date.today()).days
+                expiry = datetime(expiry_date.year, expiry_date.month, expiry_date.day, tzinfo=timezone.utc)
+            else:
+                # No existing sensor — calculate from days_remaining
+                expiry = now + timedelta(days=days_remaining)
+                remaining = days_remaining
         else:
+            # Fresh token generation — calculate new expiry
             expiry = now + timedelta(days=TOKEN_EXPIRY_DAYS)
             remaining = TOKEN_EXPIRY_DAYS
         headers = {
@@ -301,7 +325,7 @@ def update_ha_sensor(brand, username="", days_remaining=None):
                 "friendly_name": f"Bluelink Token ({brand_name} {masked_user})",
                 "device_class": "date",
                 "icon": "mdi:key-clock",
-                "generated": (now - timedelta(days=TOKEN_EXPIRY_DAYS - remaining)).strftime("%Y-%m-%d %H:%M"),
+                "generated": (expiry - timedelta(days=TOKEN_EXPIRY_DAYS)).strftime("%Y-%m-%d %H:%M"),
                 "expires": expiry.strftime("%Y-%m-%d %H:%M"),
                 "days_remaining": remaining,
                 "brand": brand,


### PR DESCRIPTION
## Problem

The Home Assistant token expiry sensor shifts forward by 1 day on every refresh cycle (~every 30 minutes around midnight).

**Root cause:** `_check_token_expiry` uses `date` arithmetic (no time component) to calculate `days_left`, then `update_ha_sensor` recalculates the expiry as `datetime.now() + timedelta(days=days_left)`. The mismatch between date-only and datetime causes a rounding error that accumulates as a +1 day drift each day.

**Example from HA history:**
- 2026-10-22 (01:50)
- 2026-10-23 (01:20)
- 2026-10-24 (00:50)
- 2026-10-25 (00:20)

## Fix

When refreshing an existing sensor (periodic 30-min loop or auto-start skip), read back the stored expiry date from HA and re-publish it as-is. Only calculate a new expiry date when a token is actually freshly generated (`days_remaining=None`).

## Files changed

- `bluelink-token/web.py`
- `bluelink-token-dev/web.py`
- `standalone/web.py`